### PR TITLE
fix: asset deployment workflow update

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      
+
 permissions:
   id-token: write
   contents: read
@@ -15,29 +15,34 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
         with:
           audience: sts.amazonaws.com
-          aws-region: 'us-east-1'
-          role-to-assume: ${{ secrets.ROLE_ARN }} 
-          
-      - name: Deploy to S3
-        uses: reggionick/s3-deploy@v4
-        with:
-          folder: .
-          files-to-include: '{.*/*.+(png|svg),*/*.+(png|svg),**.+(png|svg)}'
-          bucket: ${{ secrets.S3_BUCKET }}
-          dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-          bucket-region: ${{ secrets.S3_BUCKET_REGION }}
-          private: true
-          delete-removed: true
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.ROLE_ARN }}
+
+      - name: Deploy to S3 and invalidate CloudFront
+        env:
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+          S3_BUCKET_REGION: ${{ secrets.S3_BUCKET_REGION }}
+        run: |
+          aws s3 sync . "s3://${S3_BUCKET}" \
+            --region "${S3_BUCKET_REGION}" \
+            --exclude "*" \
+            --include "*.png" \
+            --include "*.svg" \
+            --delete
+          aws cloudfront create-invalidation \
+            --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" \
+            --paths "/*"
 
       - name: Report Status
         if: always()
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
         with:
           status: ${{ job.status }}
           notification_title: "${{ github.workflow }} has {status_message}"


### PR DESCRIPTION
Deploy updates S3; CloudFront caches old responses. Invalidation clears that cache so assets.stakek.it serves the new icons right away instead of stale 403s or old files. Same behavior the old s3-deploy action had via dist-id.

The Previous workflow failed to start: https://github.com/stakekit/assets/actions/runs/26230820507

```
The actions reggionick/s3-deploy@v4, actions/checkout@v4, ravsamhq/notify-slack-action@v2, and aws-actions/configure-aws-credentials@v4 are not allowed in stakekit/assets because all actions must be from a repository owned by your enterprise, created by GitHub, verified in the GitHub Marketplace, or match one of the patterns: SocketDev/action@*, ravsamhq/notify-slack-action@*. All actions must also be pinned to a full-length commit SHA.
```